### PR TITLE
--ambiguous includes a symlink to a file as ambiguous to that file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ obj
 cpp-dependencies
 cpp-dependencies-unittests
 
+/src/GPATH
+/src/GRTAGS
+/src/GTAGS

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,15 @@ TESTS=AnalysisCircularDependencies.cpp
 
 all: cpp-dependencies
 
+debug: cpp-dependencies-g
+
 obj/%.o: src/%.cpp
 	@mkdir -p obj
 	$(COMPILER) -c -Wall -Wextra -Wpedantic -o $@ $< -std=$(STANDARD) -O3 -MMD
+
+obj-g/%.o: src/%.cpp
+	@mkdir -p obj-g
+	$(COMPILER) -c -Wall -Wextra -Wpedantic -o $@ $< -std=$(STANDARD) -g
 
 obj/%.coverage.o: src/%.cpp
 	@mkdir -p obj
@@ -38,6 +44,10 @@ test/obj/%.coverage.o: test/%.cpp
 cpp-dependencies: $(patsubst %.cpp,obj/%.o,$(SOURCES)) obj/main.o
 	$(COMPILER) -o $@ $^ $(LDFLAGS) -O3 
 
+cpp-dependencies-g: $(patsubst %.cpp,obj-g/%.o,$(SOURCES)) obj-g/main.o
+	$(COMPILER) -o $@ $^ $(LDFLAGS) -g
+
+
 cpp-dependencies-unittests: $(patsubst %.cpp,obj/%.coverage.o,$(SOURCES)) $(patsubst %.cpp,test/obj/%.coverage.o,$(TESTS))
 	$(COMPILER) -o $@ $^ $(LDFLAGS) -O3 -lgtest -lgtest_main -pthread --coverage
 
@@ -45,7 +55,7 @@ unittest: cpp-dependencies-unittests
 	./cpp-dependencies-unittests >unittest
 
 clean:
-	rm -rf obj cpp-dependencies
+	rm -rf obj obj-g cpp_dependencies cpp-dependencies-g
 
 install:
 	cp cpp-dependencies /usr/bin

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -74,7 +74,8 @@ static void ReadCmakelist(std::unordered_map<std::string, Component *> &componen
     } while (in.good());
 }
 
-static void ReadCode(std::unordered_map<std::string, File>& files, const boost::filesystem::path &path) {
+static void ReadCode(std::unordered_map<std::string, File>& files, const boost::filesystem::path &inp_path) {
+    boost::filesystem::path path = boost::filesystem::canonical (inp_path);
     File &f = files[path.generic_string()];
     f.path = path;
     std::vector<std::string> &includes = f.rawIncludes;


### PR DESCRIPTION
In my test case './include/a.h' is a symbolic link to './src/a.h'. I am getting the following message with '--ambiguous'. I assume there should not be any message.

```
Found 1 ambiguous includes

Include for a.h
Found in : 
  included from ./src/a.cpp
Options for file: 
  ./include/a.h
  ./src/a.h

```
