### PR TITLE
Build on Ubuntu Precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ script:
   - cmake ${CMAKEFLAGS} -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_C_COMPILER=${CC} ..
   - make
   - make test
+  - make package
 
 sudo: required
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,20 @@ matrix:
       env: CMAKEFLAGS="-DWITH_BOOST=ON -DHAS_MEMRCHR=OFF" CXX=clang++
     - compiler: gcc
       os: linux
+      dist: precise
+      sudo: false
+      addons:
+        apt:
+          sources:
+            - george-edison55-precise-backports
+          packages:
+            - cmake
+            - cmake-data
+            - libboost-system-dev
+            - libboost-filesystem-dev
+      env: CMAKEFLAGS="-DWITH_BOOST=ON" CXX=g++-4.6
+    - compiler: gcc
+      os: linux
       addons:
         apt:
           sources:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,16 @@ option(WITH_MMAP "Use mmapped files" ON)
 # Whether your platform provides a fast memrchr function. If it does not, turn this off and a slower replacement will be used.
 option(HAS_MEMRCHR "Platform has memrchr function" ON)
 
+# Default package format to use when building a package with CPack
+if(APPLE)
+  set(DEFAULT_CPACK_GENERATOR "DragNDrop")
+elseif(UNIX)
+  set(DEFAULT_CPACK_GENERATOR "DEB")
+elseif(WIN32)
+  set(DEFAULT_CPACK_GENERATOR "NSIS")
+endif()
+set(CPACK_GENERATOR "${DEFAULT_CPACK_GENERATOR}" CACHE STRING "Package type to generate with CPack")
+
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 
@@ -57,3 +67,40 @@ if(WITH_TESTS)
   enable_testing()
   add_subdirectory(test)
 endif()
+
+set(CPACK_PACKAGE_NAME cpp-dependencies)
+set(CPACK_PACKAGE_VERSION_MAJOR 1)
+set(CPACK_PACKAGE_VERSION_MINOR 1)
+set(CPACK_PACKAGE_VERSION_PATCH 0)
+set(CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
+set(CPACK_PACKAGE_VENDOR "TomTom International BV")
+set(CPACK_PACKAGE_CONTACT "${CPACK_PACKAGE_VENDOR}")
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Tool to check C++ #include dependencies
+ The tool cpp-dependencies creates #include dependency information for C++
+ source code files, which it derives from scanning a full source tree.
+ .
+ The dependency information is output as .dot files, which can be visualized
+ in, for example, GraphViz.")
+set(CPACK_DEBIAN_PACKAGE_HOMEPAGE https://github.com/tomtom-international/cpp-dependencies)
+set(CPACK_DEBIAN_PACKAGE_SUGGESTS graphviz)
+set(CPACK_DEBIAN_PACKAGE_SECTION devel)
+
+if(CPACK_GENERATOR STREQUAL DEB)
+  find_program(DPKG_CMD dpkg REQUIRED)
+  if(NOT DPKG_CMD)
+    message(STATUS "Can not find dpkg in your path, default to i386.")
+    set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE i386)
+  else()
+    execute_process(COMMAND "${DPKG_CMD}" --print-architecture
+      OUTPUT_VARIABLE CPACK_DEBIAN_PACKAGE_ARCHITECTURE
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+  endif()
+
+  # Because the default package name produced by CPack fails to meet Debian packaging conventions
+  set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}_${CPACK_PACKAGE_VERSION}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}")
+endif()
+
+include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,14 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES GNU)
-  set(COMPILE_FLAGS -Wall -Wextra -Wpedantic)
+  include(CheckCXXCompilerFlag)
+
+  set(COMPILE_FLAGS -Wall -Wextra)
+
+  check_cxx_compiler_flag("-Wpedantic" PEDANTIC_SUPPORTED)
+  if(PEDANTIC_SUPPORTED)
+    list(APPEND COMPILE_FLAGS -Wpedantic)
+  endif()
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   set(COMPILE_FLAGS /W4)
   # boost gets compiled as static libs on Windows

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,7 +32,7 @@ static bool CheckVersionFile() {
 std::string targetFrom(const std::string &arg) {
     std::string target = arg;
     if (!target.empty() && target.back() == '/') {
-        target.pop_back();
+        target.erase(target.end() - 1);
     }
     std::replace(target.begin(), target.end(), '.', '/');
     return "./" + target;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,13 @@
+include(WriteCompilerDetectionHeader)
+
+write_compiler_detection_header(
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/compiler_feature_detection.h"
+  PREFIX OPTIONAL_FEATURE
+  COMPILERS GNU Clang AppleClang MSVC
+  FEATURES
+    cxx_override
+)
+
 add_executable(unittests
   AnalysisCircularDependencies.cpp
   test.cpp
@@ -5,6 +15,10 @@ add_executable(unittests
 target_link_libraries(unittests
   PRIVATE
     cpp_dependencies_coverage
+)
+target_include_directories(unittests
+  PRIVATE
+    ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 set_property(TARGET unittests APPEND PROPERTY LINK_FLAGS --coverage)

--- a/test/test.h
+++ b/test/test.h
@@ -2,6 +2,7 @@
 #define TEST_H
 
 #include <stdexcept>
+#include "compiler_feature_detection.h"
 
 class Test {
 public:
@@ -18,7 +19,7 @@ private:
   static Test* firstTest;
 };
 
-#define TEST(x) static struct Test##x : public Test { Test##x() : Test(#x) {} void Run() override; } __inst_##x; void Test##x::Run()
+#define TEST(x) static struct Test##x : public Test { Test##x() : Test(#x) {} void Run() OPTIONAL_FEATURE_OVERRIDE; } __inst_##x; void Test##x::Run()
 #define ASSERT(x) do { auto v = (x); if (!v) { throw std::runtime_error("Assertion failed: " #x); } } while(0)
 
 #endif


### PR DESCRIPTION
Given that it's described as tested and supported on Ubuntu Precise (12.04) in the README this PR adds testing for that platform on Travis and subsequently fixes the reasons why it doesn't build there.