### PR TITLE
Revisit CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 script:
   - mkdir build
   - cd build
-  - cmake ${CMAKEFLAGS} -DCMAKE_CXX_COMPILER=${CXX} -DCMAKE_C_COMPILER=${CC} ..
+  - cmake ${CMAKEFLAGS} -DCMAKE_CXX_COMPILER=${CXX} ..
   - make
   - make test
   - make package

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,10 @@ cmake_minimum_required(VERSION 3.1)
 
 project(cpp_dependencies LANGUAGES CXX)
 
-# Enables running the unit tests
-option(WITH_TESTS "Also build unit tests" ON)
+include(CTest)
+
+# Coverage build doesn't work with MSVC
+option(BUILD_COVERAGE "Build cpp_dependencies for coverage" OFF)
 
 if (WIN32)
   set(DEFAULT_BOOST OFF)
@@ -81,8 +83,7 @@ endif()
 
 add_subdirectory(src)
 
-if(WITH_TESTS)
-  enable_testing()
+if(BUILD_TESTING)
   add_subdirectory(test)
 endif()
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,18 @@
 version: 1.0.{build}
 
-clone_folder: C:\dev\cpp-dependencies
+configuration: Release
 
-build_script:
-  - cd C:\dev\cpp-dependencies
-  - md build
-  - cd build
-  - cmake -G"Visual Studio 14" -DWITH_BOOST=OFF -DHAS_MEMRCHR=OFF -DWITH_MMAP=OFF ..
-  - msbuild /m /p:Configuration=Release /p:Platform="Win32" cpp_dependencies.sln
+before_build:
+  - cmake -H. -Bbuild
+
+build:
+  parallel: true
+  project: build\PACKAGE.vcxproj
+  verbosity: minimal
 
 test_script:
-  - cmd: ctest -C Release -VV
-  - cmd: cmake --build . --config Release --target package
+  - cd build
+  - ctest -C %configuration% --output-on-failure
+
+artifacts:
+  - path: build\cpp-dependencies*.exe

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,12 @@
+# MSVC understands neither --coverage nor -O3 flag
+if (NOT MSVC)
+  if(BUILD_COVERAGE)
+    list(APPEND COMPILE_FLAGS --coverage)
+  else()
+    list(APPEND COMPILE_FLAGS -O3)
+  endif()
+endif()
+
 add_library(cpp_dependencies_lib STATIC
   Analysis.h
   CmakeRegen.h
@@ -18,45 +27,12 @@ add_library(cpp_dependencies_lib STATIC
 target_compile_options(cpp_dependencies_lib
   PUBLIC 
     ${COMPILE_FLAGS}
-    -O3
 )
 target_link_libraries(cpp_dependencies_lib
   PRIVATE 
     ${FILESYSTEM_LIBS}
 )
 target_include_directories(cpp_dependencies_lib
-  PUBLIC 
-    ${CMAKE_CURRENT_LIST_DIR}
-    ${Boost_INCLUDE_DIRS}
-)
-
-add_library(cpp_dependencies_coverage STATIC
-  Analysis.h
-  CmakeRegen.h
-  Component.h
-  Configuration.h
-  Constants.h
-  Input.h
-  Output.h
-
-  Analysis.cpp
-  CmakeRegen.cpp
-  Component.cpp
-  Configuration.cpp
-  generated.cpp
-  Input.cpp
-  Output.cpp
-)
-target_compile_options(cpp_dependencies_coverage
-  PUBLIC 
-    ${COMPILE_FLAGS}
-    --coverage
-)
-target_link_libraries(cpp_dependencies_coverage
-  PRIVATE 
-    ${FILESYSTEM_LIBS}
-)
-target_include_directories(cpp_dependencies_coverage
   PUBLIC 
     ${CMAKE_CURRENT_LIST_DIR}
     ${Boost_INCLUDE_DIRS}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,12 +4,14 @@ add_executable(unittests
 )
 target_link_libraries(unittests
   PRIVATE
-    cpp_dependencies_coverage
+    cpp_dependencies_lib
 )
 target_compile_definitions(unittests
   PRIVATE
     _CRT_SECURE_NO_WARNINGS
 )
 
-set_property(TARGET unittests APPEND PROPERTY LINK_FLAGS --coverage)
+if (NOT MSVC AND BUILD_COVERAGE)
+  set_property(TARGET unittests APPEND PROPERTY LINK_FLAGS --coverage)
+endif ()
 add_test(NAME unittests COMMAND unittests)


### PR DESCRIPTION
AppVeyor
-
Fix the AppVeyor config to use the right logger, which updates the Web UI with warnings and errors generated during the build. [Here](https://ci.appveyor.com/project/tusharpm/cpp-dependencies/build/messages) is a sample.
Upload the built cpp-dependencies installer as an artifact. [Here](https://ci.appveyor.com/project/tusharpm/cpp-dependencies/build/artifacts) is a sample.
TODO: check if the cpp-dependencies standalone executable needs to be added as another artifact.

Travis
-
Fix the unused variable `CMAKE_C_COMPILER` warning from CMake.
EDIT: reverted the language changes in Travis config.

CMake
-
Remove the `WITH_TESTS` option in favor of the conventional `BUILD_TESTING` option added by `CTest`.
Add a `BUILD_COVERAGE` option which changes the compile flags of `cpp_dependencies_lib`, rather than compiling it twice every time.
- This addresses the warnings from AppVeyor (MSVC) about the unused compiler flags.
- It is OFF by default, and is not used by any builds. This can be used later to integrate with a coverage visualization service - [codecov](https://codecov.io/) or [coveralls](https://coveralls.io/).
- Reduces the redundant mention of source files (and one target) in CMakeLists.txt.

I've kept these changes as independent commits. The ones required can be cherry-picked.
If there are concerns, please let me know. I'll try to address them.