### PR TITLE
Added cmake requirement for C++11

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,9 @@ target_include_directories(cpp_dependencies_lib
 add_executable(cpp-dependencies
   main.cpp
 )
+
+target_compile_features(cpp-dependencies PRIVATE cxx_range_for)
+
 target_link_libraries(cpp-dependencies
   PRIVATE
     cpp_dependencies_lib


### PR DESCRIPTION
Following the [cmake documentation](https://cmake.org/cmake/help/v3.1/manual/cmake-compile-features.7.html#manual:cmake-compile-features(7)) a line declaring C++11 language standard requirement was added. This tells cmake to test the compiler for the language feature, and set the compiler parameters required for the language standard.