### PR TITLE
Additional target parameters

### DIFF
--- a/src/CmakeRegen.cpp
+++ b/src/CmakeRegen.cpp
@@ -103,7 +103,7 @@ void RegenerateCmakeFilesForComponent(const Configuration& config, Component *co
             RegenerateCmakeHeader(o, config);
 
             if (comp->root == ".") {
-                // Do this for the user, so that you don't get a warning on either 
+                // Do this for the user, so that you don't get a warning on either
                 // not doing this, or doing this in the addon file.
                 o << "cmake_minimum_required(VERSION " << config.cmakeVersion << ")\n";
             }
@@ -186,30 +186,31 @@ void RegenerateCmakeAddSubdirectory(std::ostream& o,
     for (auto subdir : subdirs) {
         o << "add_subdirectory(" << subdir << ")\n";
     }
-        
+
 }
 
 void RegenerateCmakeAddTarget(std::ostream& o,
                               const Configuration& config,
-                              const Component& comp,
+                              Component& comp,
                               const std::list<std::string>& files,
                               bool isHeaderOnly) {
     o << comp.type << "(${PROJECT_NAME}";
 
     if (isHeaderOnly) {
-        o << " INTERFACE\n";
-    } else {
-        if (config.addLibraryAliases.count(comp.type) == 1) {
-            o << " STATIC\n";
-        } else {
-            o << "\n";
-        }
+        comp.additionalTargetParameters.insert("INTERFACE");
+    }
+    if (!comp.additionalTargetParameters.empty()) {
+      for (auto &s : comp.additionalTargetParameters) {
+          o << " " << s;
+      }
+    }
+    o << "\n";
 
+    if (!isHeaderOnly) {
         for (auto &f : files) {
             o << "  " << f << "\n";
         }
     }
-    o << comp.additionalTargetParameters;
     o << ")\n\n";
 }
 

--- a/src/CmakeRegen.h
+++ b/src/CmakeRegen.h
@@ -27,7 +27,7 @@ struct Configuration;
 
 void RegenerateCmakeFilesForComponent(const Configuration& config,
                                       Component *comp,
-                                      bool dryRun, 
+                                      bool dryRun,
                                       bool writeToStdout);
 
 void MakeCmakeComment(std::string& cmakeComment,
@@ -39,7 +39,7 @@ void RegenerateCmakeAddSubdirectory(std::ostream& o,
                                     const Component& comp);
 void RegenerateCmakeAddTarget(std::ostream& o,
                               const Configuration& config,
-                              const Component& comp,
+                              Component& comp,
                               const std::list<std::string>& files,
                               bool isHeaderOnly);
 void RegenerateCmakeHeader(std::ostream& o, const Configuration& config);

--- a/src/Component.h
+++ b/src/Component.h
@@ -87,7 +87,7 @@ struct Component {
     bool hasAddonCmake;
     std::string type;
     size_t index, lowlink;
-    std::string additionalTargetParameters;
+    std::set<std::string> additionalTargetParameters;
     std::string additionalCmakeDeclarations;
     bool onStack;
 };
@@ -106,5 +106,3 @@ void CreateIncludeLookupTable(std::unordered_map<std::string, File>& files,
                               std::map<std::string, std::set<std::string>> &collisions);
 
 #endif
-
-

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -276,7 +276,7 @@ static void ReadCmakelist(const Configuration& config, std::unordered_map<std::s
             {
                 inAutoSection = true;
             } else {
-                if (!inAutoSection && !line.empty()) {
+                if (!inAutoSection && !line.empty() && !inTargetDefinition) {
                     comp.additionalCmakeDeclarations.append(line + '\n');
                 }
             }
@@ -291,10 +291,10 @@ static void ReadCmakelist(const Configuration& config, std::unordered_map<std::s
                 const std::string targetLine(line.substr(0, endOfLine));
                 static const std::unordered_set<std::string> cmakeTargetParameters = { "ALIAS", "EXCLUDE_FROM_ALL", "GLOBAL", "IMPORTED", "INTERFACE", "MACOSX_BUNDLE", "MODULE", "OBJECT", "STATIC", "SHARED", "UNKNOWN", "WIN32" };
                 for (auto& cmakeTargetParameter : cmakeTargetParameters) {
-                  int pos = targetLine.find(cmakeTargetParameter.c_str());
-                  if (pos != std::string::npos) {
-                    comp.additionalTargetParameters.insert(cmakeTargetParameter);
-                  }
+                    int pos = targetLine.find(cmakeTargetParameter.c_str());
+                    if (pos != std::string::npos) {
+                        comp.additionalTargetParameters.insert(cmakeTargetParameter);
+                    }
                 }
             }
             if (newParentLevel == 0) {

--- a/test/CmakeRegenTest.cpp
+++ b/test/CmakeRegenTest.cpp
@@ -299,7 +299,7 @@ TEST(RegenerateCmakeTargetLinkLibraries_Interface) {
 TEST(RegenerateCmakeAddTarget_Interface) {
   Component comp("./MyComponent/");
   comp.type = "add_library";
-  comp.additionalTargetParameters = "  EXCLUDE_FROM_ALL\n";
+  comp.additionalTargetParameters = { "EXCLUDE_FROM_ALL" };
 
   Configuration config;
 
@@ -312,8 +312,7 @@ TEST(RegenerateCmakeAddTarget_Interface) {
   };
 
   const std::string expectedOutput(
-      "add_library(${PROJECT_NAME} INTERFACE\n"
-      "  EXCLUDE_FROM_ALL\n"
+      "add_library(${PROJECT_NAME} EXCLUDE_FROM_ALL INTERFACE\n"
       ")\n"
       "\n");
 
@@ -326,7 +325,7 @@ TEST(RegenerateCmakeAddTarget_Interface) {
 TEST(RegenerateCmakeAddTarget_Library) {
   Component comp("./MyComponent/");
   comp.type = "add_library";
-  comp.additionalTargetParameters = "  EXCLUDE_FROM_ALL\n";
+  comp.additionalTargetParameters = { "EXCLUDE_FROM_ALL" };
 
   Configuration config;
 
@@ -339,11 +338,10 @@ TEST(RegenerateCmakeAddTarget_Library) {
   };
 
   const std::string expectedOutput(
-      "add_library(${PROJECT_NAME} STATIC\n"
+      "add_library(${PROJECT_NAME} EXCLUDE_FROM_ALL\n"
       "  Analysis.cpp\n"
       "  Analysis.h\n"
       "  main.cpp\n"
-      "  EXCLUDE_FROM_ALL\n"
       ")\n"
       "\n");
 
@@ -356,7 +354,7 @@ TEST(RegenerateCmakeAddTarget_Library) {
 TEST(RegenerateCmakeAddTarget_LibraryAlias) {
   Component comp("./MyComponent/");
   comp.type = "add_library_alias";
-  comp.additionalTargetParameters = "  EXCLUDE_FROM_ALL\n";
+  comp.additionalTargetParameters = { "EXCLUDE_FROM_ALL" };
 
   Configuration config;
   config.addLibraryAliases.insert("add_library_alias");
@@ -370,11 +368,10 @@ TEST(RegenerateCmakeAddTarget_LibraryAlias) {
   };
 
   const std::string expectedOutput(
-      "add_library_alias(${PROJECT_NAME} STATIC\n"
+      "add_library_alias(${PROJECT_NAME} EXCLUDE_FROM_ALL\n"
       "  Analysis.cpp\n"
       "  Analysis.h\n"
       "  main.cpp\n"
-      "  EXCLUDE_FROM_ALL\n"
       ")\n"
       "\n");
 
@@ -387,7 +384,7 @@ TEST(RegenerateCmakeAddTarget_LibraryAlias) {
 TEST(RegenerateCmakeAddTarget_Executable) {
   Component comp("./MyComponent/");
   comp.type = "add_executable";
-  comp.additionalTargetParameters = "  EXCLUDE_FROM_ALL\n";
+  comp.additionalTargetParameters = { "EXCLUDE_FROM_ALL" };
 
   Configuration config;
 
@@ -400,11 +397,10 @@ TEST(RegenerateCmakeAddTarget_Executable) {
   };
 
   const std::string expectedOutput(
-      "add_executable(${PROJECT_NAME}\n"
+      "add_executable(${PROJECT_NAME} EXCLUDE_FROM_ALL\n"
       "  Analysis.cpp\n"
       "  Analysis.h\n"
       "  main.cpp\n"
-      "  EXCLUDE_FROM_ALL\n"
       ")\n"
       "\n");
 

--- a/test/InputTest.cpp
+++ b/test/InputTest.cpp
@@ -74,3 +74,29 @@ TEST(Input_Aliases)
     }
   }
 }
+
+TEST(Input_AdditionalTargetParameters)
+{
+  TemporaryWorkingDirectory workDir(name);
+
+  {
+    streams::ofstream out(workDir() / "CMakeLists.txt");
+    out << "project(TestProject)\n"
+        << "add_library(${PROJECT_NAME} SHARED EXCLUDE_FROM_ALL somesourcefile.cpp)\n";
+  }
+
+  Configuration config;
+
+  std::unordered_map<std::string, Component*> components;
+  std::unordered_map<std::string, File> files;
+
+  LoadFileList(config, components, files, workDir(), true, false);
+
+  ASSERT(components.size() == 1);
+
+  for (auto& pair : components) {
+    const Component& comp = *pair.second;
+    ASSERT(comp.additionalTargetParameters.size() == 2);
+    ASSERT(*comp.additionalTargetParameters.begin() == "EXCLUDE_FROM_ALL");
+  }
+}


### PR DESCRIPTION
This will allow users freedom to specify additional target parameters in `add_executable()` and `add_library()` in more relaxed way, e.g:
```
add_library(MY_PROJECT_1 SHARED EXCLUDE_FROM_ALL my_source_1.cpp)
add_library(MY_PROJECT_2
  SHARED
  EXCLUDE_FROM_ALL
  my_source_2.cpp
)
```

Next it will no longer enforce the usage of `STATIC` libraries by default after regeneration, but leave the possibility for the user to leave it blank and obtain then then the default setting of CMake which is `STATIC` anyway. That behaviour can in turn then easily be adjusted by using the CMake flag `BUILD_SHARED_LIBS`.