### PR TITLE
Updated project to build wwith C++20 and std::filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 4.0)
 
 project(cpp_dependencies LANGUAGES CXX)
 
@@ -45,7 +45,7 @@ elseif(WIN32)
 endif()
 set(CPACK_GENERATOR "${DEFAULT_CPACK_GENERATOR}" CACHE STRING "Package type to generate with CPack")
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES GNU)

--- a/src/FilesystemInclude.h
+++ b/src/FilesystemInclude.h
@@ -3,15 +3,26 @@
 
 #ifdef WITH_BOOST
 
-#include <boost/filesystem.hpp>
-
-namespace filesystem = boost::filesystem;
+    #include <boost/filesystem.hpp>
+    namespace filesystem = boost::filesystem;
 
 #else
+#   if __cplusplus >= 201703L
+    #include <filesystem>
+    namespace filesystem = std::filesystem;
 
-#include <experimental/filesystem>
+    // Code specific to C++17 or later
+    #define HAS_CPP17_FEATURES
+#   elif __cplusplus >= 201103L
+    #include <experimental/filesystem>
+    namespace filesystem = std::experimental::filesystem;
 
-namespace filesystem = std::experimental::filesystem;
+    // Code specific to C++11 or later (but not C++17)
+    #define HAS_CPP11_FEATURES
+#   else
+    // Code for older C++ versions (e.g., C++98/03)
+    #pragma error("C++ version is too old, please use C++11 or later.")
+#   endif
 
 #endif
 


### PR DESCRIPTION
Building this project with somewhat new toolchain (gcc-15.1) brought me to hundreds of linker errors on `std::experimental::filesystem`.

The quickest and easiest solution was to bump the configuration to C++20 (OK, it could be C++17) and use `std::experimental`.

Later it may be adequate to tinker with linker flags to make it build again with C++11, but being honest, we are in 2025!
